### PR TITLE
feat: introduce `TrustedTypes`

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
         "@rollup/plugin-terser": "^0.4.4",
         "@rollup/plugin-typescript": "^12.1.2",
         "@trivago/prettier-plugin-sort-imports": "^5.2.2",
+        "@types/trusted-types": "^2.0.7",
         "prettier": "^3.5.3",
         "prettier-plugin-css-order": "^2.1.2",
         "rollup": "^4.35.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@trivago/prettier-plugin-sort-imports':
         specifier: ^5.2.2
         version: 5.2.2(prettier@3.5.3)
+      '@types/trusted-types':
+        specifier: ^2.0.7
+        version: 2.0.7
       prettier:
         specifier: ^3.5.3
         version: 3.5.3
@@ -749,6 +752,9 @@ packages:
 
   '@types/react@19.0.10':
     resolution: {integrity: sha512-JuRQ9KXLEjaUNjTWpzuR231Z2WpIwczOkBEIvbHNCzQefFIT0L8IqE6NV6ULLyC1SI/i234JnDoMkfg+RjQj2g==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@typescript-eslint/eslint-plugin@8.26.1':
     resolution: {integrity: sha512-2X3mwqsj9Bd3Ciz508ZUtoQQYpOhU/kWoUqIf49H8Z0+Vbh6UF/y0OEYp0Q0axOGzaBGs7QxRwq0knSQ8khQNA==}
@@ -3217,6 +3223,8 @@ snapshots:
   '@types/react@19.0.10':
     dependencies:
       csstype: 3.1.3
+
+  '@types/trusted-types@2.0.7': {}
 
   '@typescript-eslint/eslint-plugin@8.26.1(@typescript-eslint/parser@8.26.1(eslint@9.22.0(jiti@1.21.7))(typescript@4.9.5))(eslint@9.22.0(jiti@1.21.7))(typescript@4.9.5)':
     dependencies:

--- a/src/toast.ts
+++ b/src/toast.ts
@@ -2,6 +2,7 @@ import { closeIcon } from './assets';
 import { errorIcon, infoIcon, loadingIcon, successIcon, warningIcon } from './assets';
 import { config } from './config';
 import { assignOffset, getToaster } from './toaster';
+import { __unsafeCreateTrustedHtml } from './trusted-types';
 import { ToastType } from './types';
 
 const icons = { success: successIcon, error: errorIcon, info: infoIcon, warning: warningIcon, loading: loadingIcon };
@@ -34,7 +35,8 @@ export function addToast(options: ToastType) {
     // add close button
     const close = document.createElement('button');
     close.setAttribute('data-close-button', closeButton.toString());
-    close.innerHTML = closeIcon;
+    // we already know our icon would be safe
+    close.innerHTML = __unsafeCreateTrustedHtml(closeIcon);
     close.addEventListener('click', () => {
         dismissToast(id);
         onDismiss();
@@ -43,7 +45,8 @@ export function addToast(options: ToastType) {
 
     if (options.type) {
         const icon = document.createElement('span');
-        icon.innerHTML = icons[options.type];
+        // we already know our icons would be safe
+        icon.innerHTML = __unsafeCreateTrustedHtml(icons[options.type]);
         icon.setAttribute('data-icon', '');
         toast.appendChild(icon);
 
@@ -61,7 +64,9 @@ export function addToast(options: ToastType) {
 
     const title = document.createElement('div');
     title.setAttribute('data-title', '');
-    title.innerHTML = options.title;
+
+    // the title is supplemented with user content, we can only assume it might be safe
+    title.innerHTML = __unsafeCreateTrustedHtml(options.title);
     content.appendChild(title);
 
     if (options.description) {

--- a/src/trusted-types.ts
+++ b/src/trusted-types.ts
@@ -1,0 +1,41 @@
+
+function identity<T>(x: T): T {
+  return x
+}
+
+/**
+ * Stores the Trusted Types Policy. Starts as undefined and can be set to null
+ * if Trusted Types is not supported in the browser.
+ */
+let policy: TrustedTypePolicy | null | undefined
+
+/**
+ * Getter for the Trusted Types Policy. If it is undefined, it is instantiated
+ * here or set to null if Trusted Types is not supported in the browser.
+ */
+function getPolicy() {
+  if (typeof policy === 'undefined' && typeof window !== 'undefined') {
+    policy =
+      window.trustedTypes?.createPolicy('sonner-js', {
+        createHTML: identity,
+        createScript: identity,
+        createScriptURL: identity,
+      }) || null
+  }
+
+  return policy
+}
+
+/**
+ * Unsafely promote a string to a TrustedHTML, falling back to strings
+ * when Trusted Types are not available.
+ * This is a security-sensitive function; any use of this function
+ * must go through security review. In particular, it must be assured that the
+ * provided string will never cause an XSS vulnerability if used in a context
+ * that will cause a browser to execute a script
+ */
+export function __unsafeCreateTrustedHtml(
+  html: string
+): string {
+  return (getPolicy()?.createHTML(html) || html) as string
+}


### PR DESCRIPTION
I am trying to use `sonner-js` in my UserScript project. Turns out that the target website is enforcing "[Trusted Types Policy](https://developer.mozilla.org/en-US/docs/Web/API/TrustedHTML)", and `.innerHTML =` will trigger `This document requires 'TrustedHTML' assignment` error.

The PR creates a trusted type policy that promotes an input HTML string into `TrustedHTML` w/o transformation, to bypass the `'TrustedHTML' assignment` error.